### PR TITLE
Create a Docker image with tuleap-rest-api-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3
+
+WORKDIR /tmp
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN python setup.py install
+

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(name='tuleap-rest-api-client',
       author='xxx',
       author_email='xxx@example.com',
       url='https://www.example.com',
-      install_requires=install_requires
+      install_requires=install_requires,
+      packages=['Tuleap', 'Tuleap/RestClient']
       )


### PR DESCRIPTION
A Docker container is useful in order to handle Tuleap API directly from Jenkins, for example.